### PR TITLE
improve weighted author search

### DIFF
--- a/embedding_search/data_model.py
+++ b/embedding_search/data_model.py
@@ -17,6 +17,9 @@ class Article:
     abstract: str = None
     cited_by: int = None
 
+    def __post_init__(self) -> None:
+        self.author_orcid = extract_orcid(self.orcid_path)
+
     @property
     def text(self) -> str:
         """Text to embed."""
@@ -34,6 +37,7 @@ class Article:
         return {
             "type": "article",
             "orcid_path": self.orcid_path,
+            "author_orcid": self.author_orcid,
             "doi": self.doi,
             "title": self.title,
             "url": self.url,
@@ -44,13 +48,10 @@ class Article:
             "cited_by": self.cited_by,
         }
 
-    @property
-    def author_orcid(self) -> str:
-        return extract_orcid(self.orcid_path)
-
     def to_dict(self) -> dict:
         return {
             "orcid_path": self.orcid_path,
+            "author_orcid": self.author_orcid,
             "doi": self.doi,
             "title": self.title,
             "url": self.url,

--- a/embedding_search/vector_store.py
+++ b/embedding_search/vector_store.py
@@ -96,7 +96,11 @@ class MiniStore:
             metadata = self.metadata[i]
             logging.info(metadata)
             output = constructor_fn(
-                **{k: v for k, v in metadata.items() if k != "type"}
+                **{
+                    k: v
+                    for k, v in metadata.items()
+                    if k not in ("type", "author_orcid")
+                }
             )
             output.distance = distances[i]
             outputs.append(output)

--- a/notebooks/working.ipynb
+++ b/notebooks/working.ipynb
@@ -1,6 +1,59 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from embedding_search.vector_store import MiniStore\n",
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(level=logging.INFO)\n",
+    "store = MiniStore()\n",
+    "store.build()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scores = store.weighted_search_author(query=\"Higgs boson\", top_k=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[print(s) for s in scores]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for s in sorted_orcids:\n",
+    "    print(scores[s])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from embedding_search.utils import sort_key_by_value\n",
+    "\n",
+    "sorted_orcids = sort_key_by_value(scores, reversed=True)"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/notebooks/working.ipynb
+++ b/notebooks/working.ipynb
@@ -9,7 +9,7 @@
     "from embedding_search.vector_store import MiniStore\n",
     "import logging\n",
     "\n",
-    "logging.basicConfig(level=logging.INFO)\n",
+    "logging.basicConfig(level=logging.DEBUG)\n",
     "store = MiniStore()\n",
     "store.build()"
    ]
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scores = store.weighted_search_author(query=\"Higgs boson\", top_k=3)"
+    "authors = store.weighted_search_author(query=\"Reading and writing\", top_k=3)"
    ]
   },
   {
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "[print(s) for s in scores]"
+    "[print(a, a.weighted_score) for a in authors]"
    ]
   },
   {


### PR DESCRIPTION
Addressing #1 and improve weighting function to:

Each author is given by a score, defined as:
$$ S_j = \sum_{i=1}^n (1 - d_{i,j})^p $$

where $d_{i,j}$ is the distance between the query and the $i$-th article of the $j$-th author.

The value $d$ is also clipped by the `distance_threshold` $t$, i.e.,

$$
d = 
\begin{cases} 
d & \text{if } d \leq t \\
1 & \text{if } d > t 
 end{cases}
 $$